### PR TITLE
feat: add StockFlow options page

### DIFF
--- a/app/api/options/route.ts
+++ b/app/api/options/route.ts
@@ -1,0 +1,28 @@
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const symbol = url.searchParams.get("symbol");
+
+  if (!symbol) {
+    return Response.json({ message: "Symbol is required" }, { status: 400 });
+  }
+
+  try {
+    const response = await fetch(
+      `https://query2.finance.yahoo.com/v7/finance/options/${symbol}`
+    );
+
+    if (!response.ok) {
+      throw new Error("Failed to fetch options data");
+    }
+
+    const data = await response.json();
+    return Response.json(data);
+  } catch (error) {
+    return Response.json(
+      { message: "Failed to fetch options data" },
+      { status: 500 }
+    );
+  }
+}
+
+export const dynamic = "force-dynamic";

--- a/app/stockflow/page.tsx
+++ b/app/stockflow/page.tsx
@@ -1,0 +1,73 @@
+"use client";
+import { useState } from "react";
+
+export default function StockflowPage() {
+  const [symbol, setSymbol] = useState("");
+  const [data, setData] = useState<any>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchOptions = async () => {
+    setError(null);
+    setData(null);
+    try {
+      const res = await fetch(`/api/options?symbol=${symbol}`);
+      if (!res.ok) {
+        throw new Error("Request failed");
+      }
+      const json = await res.json();
+      setData(json);
+    } catch (e: any) {
+      setError(e.message);
+    }
+  };
+
+  const options = data?.optionChain?.result?.[0]?.options?.[0];
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl mb-2">StockFlow Options</h1>
+      <input
+        className="border p-1 mr-2"
+        placeholder="Ticker"
+        value={symbol}
+        onChange={(e) => setSymbol(e.target.value)}
+      />
+      <button
+        onClick={fetchOptions}
+        className="bg-blue-500 text-white px-3 py-1 rounded"
+      >
+        Fetch
+      </button>
+      {error && <p className="text-red-600 mt-2">{error}</p>}
+      {options && (
+        <div className="mt-4 overflow-x-auto">
+          <table className="min-w-full text-sm">
+            <thead>
+              <tr>
+                <th className="px-2 py-1 text-left">Type</th>
+                <th className="px-2 py-1 text-left">Strike</th>
+                <th className="px-2 py-1 text-left">Last Price</th>
+              </tr>
+            </thead>
+            <tbody>
+              {options.calls.map((call: any) => (
+                <tr key={`call-${call.contractSymbol}`}>
+                  <td className="border px-2 py-1">Call</td>
+                  <td className="border px-2 py-1">{call.strike}</td>
+                  <td className="border px-2 py-1">{call.lastPrice}</td>
+                </tr>
+              ))}
+              {options.puts.map((put: any) => (
+                <tr key={`put-${put.contractSymbol}`}>
+                  <td className="border px-2 py-1">Put</td>
+                  <td className="border px-2 py-1">{put.strike}</td>
+                  <td className="border px-2 py-1">{put.lastPrice}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -30,6 +30,9 @@ export const Navigation = () => {
                   />
                 </svg>
               </Link>
+              <Link href="/stockflow">
+                <span className="text-white ml-4 mt-1">StockFlow</span>
+              </Link>
               <Link
                 href="https://docs.cdp.coinbase.com/mpc-wallet/docs/quickstart"
                 target="_blank"


### PR DESCRIPTION
## Summary
- add StockFlow options page showing Yahoo option chains
- proxy Yahoo Finance requests through `/api/options` to bypass CORS
- link to new page in navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b551df3b60832ba92f17fac4550c18